### PR TITLE
changed group from wcadmin to haproxy_group 

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -13,7 +13,7 @@
     state: directory
     path: "{{ item }}"
     owner: "{{ haproxy_user }}"
-    group: wcadmin
+    group: "{{ haproxy_group }}"
     mode: 0775
   with_items:
     - "{{ haproxy_runtime_root }}"


### PR DESCRIPTION
It was failing out with error: 

`msg: chgrp failed: failed to look up group wcadmin`
